### PR TITLE
Remove root element alias from normalizers and hydrators containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $formats = new FormatContainer();
 $formats->add('json', new JsonFormat());
 
 $normalizers = new FallbackNormalizerContainer();
-$normalizers->add(User::class, 'user', function(User $user) {
+$normalizers->add(User::class, function(User $user) {
     return [
         'id' => $user->getId(),
         'name' => $user->getName(),
@@ -85,7 +85,7 @@ $formats->add('json', new JsonFormat());
 $normalizers = new FallbackNormalizerContainer();
 
 $hydrators = new FallbackHydratorContainer();
-$hydrators->add(User::class, 'user', function(array $data) {
+$hydrators->add(User::class, function(array $data) {
     return new User($data['id'], $data['name']);
 });
 
@@ -111,8 +111,8 @@ Several formats are supported as classes in `Thunder\Serializard\Format`:
 
 - **JSON** in `JsonFormat` converts objects to JSON,
 - **Array** in `ArrayFormat` just returns object graph normalized to arrays of scalars,
-- **YAML** in `YamlFormat` converts objects to YAML,
-- **XML** in `XmlFormat` converts objects to XML.
+- **YAML** in `YamlFormat` converts objects to YAML (uses `symfony/yaml`),
+- **XML** in `XmlFormat` converts objects to XML (uses `ext-dom`).
 
 # License
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "email": "tomasz@kowalczyk.cc"
     }],
     "require": {
-        "php": "^5.3|^7.0",
+        "php": "^5.5|^7.0",
         "symfony/yaml": "^2.3|^3.0"
     },
     "require-dev": {

--- a/src/Format/XmlFormat.php
+++ b/src/Format/XmlFormat.php
@@ -13,12 +13,8 @@ final class XmlFormat implements FormatInterface
     /** @var callable */
     private $rootProvider;
 
-    public function __construct($rootProvider = null)
+    public function __construct(callable $rootProvider)
     {
-        if($rootProvider && false === is_callable($rootProvider)) {
-            throw new \InvalidArgumentException('XML format root element name provider must be callable!');
-        }
-
         $this->rootProvider = $rootProvider;
     }
 
@@ -115,10 +111,6 @@ final class XmlFormat implements FormatInterface
 
     private function getRoot($class)
     {
-        if(null === $this->rootProvider) {
-            throw new \RuntimeException('No root provider!');
-        }
-
         return call_user_func($this->rootProvider, $class);
     }
 }

--- a/src/HydratorContainer/FallbackHydratorContainer.php
+++ b/src/HydratorContainer/FallbackHydratorContainer.php
@@ -10,17 +10,17 @@ final class FallbackHydratorContainer implements HydratorContainerInterface
     private $interfaces = array();
     private $aliases = array();
 
-    public function add($class, $root, $handler)
+    public function add($class, $handler)
     {
         if(false === is_callable($handler)) {
             throw new \RuntimeException(sprintf('Invalid handler for class %s!', $class));
         }
 
         if(class_exists($class)) {
-            $this->aliases[$class] = $root;
+            $this->aliases[$class] = $class;
             $this->handlers[$class] = $handler;
         } elseif(interface_exists($class)) {
-            $this->aliases[$class] = $root;
+            $this->aliases[$class] = $class;
             $this->interfaces[$class] = $handler;
         } else {
             throw new \RuntimeException(sprintf('Given value %s is neither class nor interface name!', $class));
@@ -37,11 +37,6 @@ final class FallbackHydratorContainer implements HydratorContainerInterface
 
         $this->handlers[$alias] = $handler;
         $this->aliases[$alias] = $this->aliases[$class];
-    }
-
-    public function getRoot($class)
-    {
-        return $this->aliases[$class];
     }
 
     public function getHandler($class)

--- a/src/HydratorContainer/HydratorContainerInterface.php
+++ b/src/HydratorContainer/HydratorContainerInterface.php
@@ -9,13 +9,6 @@ interface HydratorContainerInterface
     /**
      * @param string $class Class name
      *
-     * @return string
-     */
-    public function getRoot($class);
-
-    /**
-     * @param string $class Class name
-     *
      * @return callable
      */
     public function getHandler($class);

--- a/src/NormalizerContainer/FallbackNormalizerContainer.php
+++ b/src/NormalizerContainer/FallbackNormalizerContainer.php
@@ -10,17 +10,17 @@ final class FallbackNormalizerContainer implements NormalizerContainerInterface
     private $interfaces = array();
     private $aliases = array();
 
-    public function add($class, $root, $handler)
+    public function add($class, $handler)
     {
         if(false === is_callable($handler)) {
             throw new \RuntimeException(sprintf('Invalid handler for class %s!', $class));
         }
 
         if(class_exists($class)) {
-            $this->aliases[$class] = $root;
+            $this->aliases[$class] = $class;
             $this->handlers[$class] = $handler;
         } elseif(interface_exists($class)) {
-            $this->aliases[$class] = $root;
+            $this->aliases[$class] = $class;
             $this->interfaces[$class] = $handler;
         } else {
             throw new \RuntimeException(sprintf('Given value %s is neither class nor interface name!', $class));
@@ -37,11 +37,6 @@ final class FallbackNormalizerContainer implements NormalizerContainerInterface
 
         $this->handlers[$alias] = $handler;
         $this->aliases[$alias] = $this->aliases[$class];
-    }
-
-    public function getRoot($class)
-    {
-        return $this->aliases[$class];
     }
 
     public function getHandler($class)

--- a/src/NormalizerContainer/NormalizerContainerInterface.php
+++ b/src/NormalizerContainer/NormalizerContainerInterface.php
@@ -9,13 +9,6 @@ interface NormalizerContainerInterface
     /**
      * @param string $class Class name
      *
-     * @return string
-     */
-    public function getRoot($class);
-
-    /**
-     * @param string $class Class name
-     *
      * @return callable
      */
     public function getHandler($class);

--- a/src/SerializardFacade.php
+++ b/src/SerializardFacade.php
@@ -41,14 +41,14 @@ final class SerializardFacade
         $this->formats->add($alias, $format);
     }
 
-    public function addNormalizer($class, $root, $handler)
+    public function addNormalizer($class, $handler)
     {
-        $this->normalizers->add($class, $root, $handler);
+        $this->normalizers->add($class, $handler);
     }
 
-    public function addHydrator($class, $root, $handler)
+    public function addHydrator($class, $handler)
     {
-        $this->hydrators->add($class, $root, $handler);
+        $this->hydrators->add($class, $handler);
     }
 
     public function serialize($var, $format)

--- a/src/SerializardFacade.php
+++ b/src/SerializardFacade.php
@@ -10,6 +10,7 @@ use Thunder\Serializard\FormatContainer\FormatContainer;
 use Thunder\Serializard\HydratorContainer\FallbackHydratorContainer;
 use Thunder\Serializard\NormalizerContainer\FallbackNormalizerContainer;
 use Thunder\Serializard\NormalizerContext\ParentNormalizerContext;
+use Thunder\Serializard\Utility\RootElementProviderUtility;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
@@ -32,7 +33,7 @@ final class SerializardFacade
         $formats->add('json', new JsonFormat());
         $formats->add('array', new ArrayFormat());
         $formats->add('yaml', new YamlFormat());
-        $formats->add('xml', new XmlFormat());
+        $formats->add('xml', new XmlFormat(new RootElementProviderUtility([])));
         $this->formats = $formats;
     }
 

--- a/src/Utility/RootElementProviderUtility.php
+++ b/src/Utility/RootElementProviderUtility.php
@@ -1,0 +1,30 @@
+<?php
+namespace Thunder\Serializard\Utility;
+
+final class RootElementProviderUtility
+{
+    private $aliases;
+
+    public function __construct(array $aliases)
+    {
+        foreach($aliases as $key => $alias) {
+            if(false === is_string($key)) {
+                throw new \InvalidArgumentException('Invalid alias class name, string required!');
+            }
+            if(false === is_string($alias)) {
+                throw new \InvalidArgumentException(sprintf('Invalid alias for class %s, string required!', $key));
+            }
+        }
+
+        $this->aliases = $aliases;
+    }
+
+    public function __invoke($class)
+    {
+        if(false === array_key_exists($class, $this->aliases)) {
+            throw new \RuntimeException(sprintf('No root element alias for class %s!', $class));
+        }
+
+        return $this->aliases[$class];
+    }
+}

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -20,8 +20,8 @@ final class FacadeTest extends AbstractTestCase
 
         $facade = new SerializardFacade();
         $facade->addFormat('thunder', new JsonFormat());
-        $facade->addNormalizer($userClass, 'user', new ReflectionNormalizer(array('tag', 'tags')));
-        $facade->addHydrator($userClass, 'user', function(array $data) {
+        $facade->addNormalizer($userClass, new ReflectionNormalizer(array('tag', 'tags')));
+        $facade->addHydrator($userClass, function(array $data) {
             return new FakeUser($data['id'], $data['name'], new FakeTag(1, 'name'));
         });
 

--- a/tests/HydratorContainerTest.php
+++ b/tests/HydratorContainerTest.php
@@ -11,7 +11,7 @@ final class HydratorContainerTest extends AbstractTestCase
     public function testAlias()
     {
         $handlers = new FallbackHydratorContainer();
-        $handlers->add('stdClass', 'std', function() { return 'value'; });
+        $handlers->add('stdClass', function() { return 'value'; });
         $handlers->addAlias('DateTime', 'stdClass');
 
         $this->assertSame('value', call_user_func($handlers->getHandler('stdClass')));
@@ -24,7 +24,7 @@ final class HydratorContainerTest extends AbstractTestCase
         $interfaceName = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeInterface';
         $interfaceTypeA = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeA';
         $interfaceTypeB = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeB';
-        $hydrators->add($interfaceName, 'type', function() { return 'type'; });
+        $hydrators->add($interfaceName, function() { return 'type'; });
 
         $this->assertSame('type', call_user_func($hydrators->getHandler($interfaceTypeA)));
         $this->assertSame('type', call_user_func($hydrators->getHandler($interfaceTypeB)));
@@ -36,7 +36,7 @@ final class HydratorContainerTest extends AbstractTestCase
         $ancestorName = 'Thunder\Serializard\Tests\Fake\FakeUserParentParent';
         $parentName = 'Thunder\Serializard\Tests\Fake\FakeUserParent';
         $userName = 'Thunder\Serializard\Tests\Fake\FakeUser';
-        $hydrators->add($ancestorName, 'type', function() { return 'ancestor'; });
+        $hydrators->add($ancestorName, function() { return 'ancestor'; });
 
         $this->assertSame('ancestor', call_user_func($hydrators->getHandler($ancestorName)));
         $this->assertSame('ancestor', call_user_func($hydrators->getHandler($parentName)));
@@ -50,8 +50,8 @@ final class HydratorContainerTest extends AbstractTestCase
         $typeMultiple = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeMultiple';
 
         $hydrators = new FallbackHydratorContainer();
-        $hydrators->add($typeInterface, 'type', function() { return 'multiple'; });
-        $hydrators->add($typeAnother, 'type', function() { return 'multiple'; });
+        $hydrators->add($typeInterface, function() { return 'multiple'; });
+        $hydrators->add($typeAnother, function() { return 'multiple'; });
 
         $this->expectException('RuntimeException');
         $hydrators->getHandler($typeMultiple);
@@ -61,7 +61,7 @@ final class HydratorContainerTest extends AbstractTestCase
     {
         $handlers = new FallbackHydratorContainer();
         $this->expectException('RuntimeException');
-        $handlers->add('invalid', 'root', function() {});
+        $handlers->add('invalid', function() {});
     }
 
     public function testAliasForInvalidClass()
@@ -75,6 +75,6 @@ final class HydratorContainerTest extends AbstractTestCase
     {
         $handlers = new FallbackHydratorContainer();
         $this->expectException('RuntimeException');
-        $handlers->add('stdClass', 'name', 'invalid');
+        $handlers->add('stdClass', 'invalid');
     }
 }

--- a/tests/NormalizerContainerTest.php
+++ b/tests/NormalizerContainerTest.php
@@ -11,7 +11,7 @@ final class NormalizerContainerTest extends AbstractTestCase
     public function testAlias()
     {
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add('stdClass', 'std', function() { return 'value'; });
+        $normalizers->add('stdClass', function() { return 'value'; });
         $normalizers->addAlias('DateTime', 'stdClass');
 
         $this->assertSame('value', call_user_func($normalizers->getHandler('stdClass')));
@@ -24,7 +24,7 @@ final class NormalizerContainerTest extends AbstractTestCase
         $interfaceName = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeInterface';
         $interfaceTypeA = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeA';
         $interfaceTypeB = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeB';
-        $normalizers->add($interfaceName, 'type', function() { return 'type'; });
+        $normalizers->add($interfaceName, function() { return 'type'; });
 
         $this->assertSame('type', call_user_func($normalizers->getHandler($interfaceTypeA)));
         $this->assertSame('type', call_user_func($normalizers->getHandler($interfaceTypeB)));
@@ -36,7 +36,7 @@ final class NormalizerContainerTest extends AbstractTestCase
         $ancestorName = 'Thunder\Serializard\Tests\Fake\FakeUserParentParent';
         $parentName = 'Thunder\Serializard\Tests\Fake\FakeUserParent';
         $userName = 'Thunder\Serializard\Tests\Fake\FakeUser';
-        $normalizers->add($ancestorName, 'type', function() { return 'ancestor'; });
+        $normalizers->add($ancestorName, function() { return 'ancestor'; });
 
         $this->assertSame('ancestor', call_user_func($normalizers->getHandler($ancestorName)));
         $this->assertSame('ancestor', call_user_func($normalizers->getHandler($parentName)));
@@ -50,8 +50,8 @@ final class NormalizerContainerTest extends AbstractTestCase
         $typeMultiple = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeMultiple';
 
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($typeInterface, 'type', function() { return 'multiple'; });
-        $normalizers->add($typeAnother, 'type', function() { return 'multiple'; });
+        $normalizers->add($typeInterface, function() { return 'multiple'; });
+        $normalizers->add($typeAnother, function() { return 'multiple'; });
 
         $this->expectException('RuntimeException');
         $normalizers->getHandler($typeMultiple);
@@ -61,7 +61,7 @@ final class NormalizerContainerTest extends AbstractTestCase
     {
         $normalizers = new FallbackNormalizerContainer();
         $this->expectException('RuntimeException');
-        $normalizers->add('invalid', 'root', function() {});
+        $normalizers->add('invalid', function() {});
     }
 
     public function testAliasForInvalidClass()
@@ -75,6 +75,6 @@ final class NormalizerContainerTest extends AbstractTestCase
     {
         $normalizers = new FallbackNormalizerContainer();
         $this->expectException('RuntimeException');
-        $normalizers->add('stdClass', 'name', 'invalid');
+        $normalizers->add('stdClass', 'invalid');
     }
 }

--- a/tests/SerializardTest.php
+++ b/tests/SerializardTest.php
@@ -13,7 +13,6 @@ use Thunder\Serializard\HydratorContainer\HydratorContainerInterface;
 use Thunder\Serializard\Normalizer\ReflectionNormalizer;
 use Thunder\Serializard\NormalizerContainer\FallbackNormalizerContainer;
 use Thunder\Serializard\NormalizerContext\NormalizerContextInterface;
-use Thunder\Serializard\NormalizerContext\ParentNormalizerContext;
 use Thunder\Serializard\Serializard;
 use Thunder\Serializard\Tests\Fake\Context\FakeNormalizerContext;
 use Thunder\Serializard\Tests\Fake\FakeArticle;
@@ -75,7 +74,7 @@ final class SerializardTest extends AbstractTestCase
     {
         $interface = 'Thunder\Serializard\Tests\Fake\Interfaces\TypeInterface';
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($interface, 'type', function(TypeInterface $type) {
+        $normalizers->add($interface, function(TypeInterface $type) {
             return array(
                 'type' => $type->getType(),
                 'value' => $type->getValue(),
@@ -100,8 +99,8 @@ final class SerializardTest extends AbstractTestCase
         $tagClass = 'Thunder\Serializard\Tests\Fake\FakeTag';
 
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($userClass, 'user', new ReflectionNormalizer());
-        $normalizers->add($tagClass, 'tag', new ReflectionNormalizer());
+        $normalizers->add($userClass, new ReflectionNormalizer());
+        $normalizers->add($tagClass, new ReflectionNormalizer());
 
         $hydrators = new FallbackHydratorContainer();
 
@@ -138,8 +137,8 @@ final class SerializardTest extends AbstractTestCase
         $tagClass = 'Thunder\Serializard\Tests\Fake\FakeTag';
 
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($userClass, 'user', new ReflectionNormalizer());
-        $normalizers->add($tagClass, 'tag', function(FakeTag $tag) {
+        $normalizers->add($userClass, new ReflectionNormalizer());
+        $normalizers->add($tagClass, function(FakeTag $tag) {
             return array(
                 'id' => $tag->getId(),
                 'name' => $tag->getName(),
@@ -147,7 +146,7 @@ final class SerializardTest extends AbstractTestCase
         });
 
         $hydrators = new FallbackHydratorContainer();
-        $hydrators->add($userClass, 'user', function(array $data, Hydrators $handlers) use($tagClass) {
+        $hydrators->add($userClass, function(array $data, Hydrators $handlers) use($tagClass) {
             $tagHandler = $handlers->getHandler($tagClass);
 
             $user = new FakeUser($data['id'], $data['name'], $tagHandler($data['tag'], $handlers));
@@ -157,12 +156,23 @@ final class SerializardTest extends AbstractTestCase
 
             return $user;
         });
-        $hydrators->add($tagClass, 'tag', function(array $data, Hydrators $handlers) {
+        $hydrators->add($tagClass, function(array $data, Hydrators $handlers) {
             return new FakeTag($data['id'], $data['name']);
         });
 
         $formats = new FormatContainer();
-        $formats->add('xml', new XmlFormat());
+        $formats->add('xml', new XmlFormat(function($class) {
+            static $aliases = [
+                FakeUser::class => 'user',
+                FakeTag::class => 'tag',
+            ];
+
+            if(false === array_key_exists($class, $aliases)) {
+                throw new \RuntimeException(sprintf('No tag name for class %s!', $class));
+            }
+
+            return $aliases[$class];
+        }));
         $formats->add('yaml', new YamlFormat());
         $formats->add('json', new JsonFormat());
         $formats->add('array', new ArrayFormat());
@@ -181,13 +191,13 @@ final class SerializardTest extends AbstractTestCase
         $hydrators = new FallbackHydratorContainer();
         $serializard = new Serializard($formats, $normalizers, $hydrators);
 
-        $normalizers->add($userClass.'ParentParent', 'user', function(FakeUserParentParent $user) { return 'ancestor'; });
+        $normalizers->add($userClass.'ParentParent', function(FakeUserParentParent $user) { return 'ancestor'; });
         $this->assertSame('ancestor', $serializard->serialize($user, 'array'));
 
-        $normalizers->add($userClass.'Parent', 'user', function(FakeUserParent $user) { return 'parent'; });
+        $normalizers->add($userClass.'Parent', function(FakeUserParent $user) { return 'parent'; });
         $this->assertSame('parent', $serializard->serialize($user, 'array'));
 
-        $normalizers->add($userClass, 'user', function(FakeUser $user) { return 'user'; });
+        $normalizers->add($userClass, function(FakeUser $user) { return 'user'; });
         $this->assertSame('user', $serializard->serialize($user, 'array'));
     }
 
@@ -202,13 +212,13 @@ final class SerializardTest extends AbstractTestCase
 
         $hydrators = new FallbackHydratorContainer();
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($articleClass, 'article', function(FakeArticle $article) {
+        $normalizers->add($articleClass, function(FakeArticle $article) {
             return $article->getTag();
         });
-        $normalizers->add($userClass, 'user', function(FakeUser $user) {
+        $normalizers->add($userClass, function(FakeUser $user) {
             return $user->getTag();
         });
-        $normalizers->add($tagClass, 'tag', function(FakeTag $tag, NormalizerContextInterface $context) {
+        $normalizers->add($tagClass, function(FakeTag $tag, NormalizerContextInterface $context) {
             return get_class($context->getParent());
         });
 
@@ -234,13 +244,13 @@ final class SerializardTest extends AbstractTestCase
         $formats->add('json', new JsonFormat());
 
         $hydrators = new FallbackHydratorContainer();
-        $hydrators->add($articleClass, 'article', function(array $data, HydratorContainerInterface $hydrators) use($tagClass, $userClass) {
+        $hydrators->add($articleClass, function(array $data, HydratorContainerInterface $hydrators) use($tagClass, $userClass) {
             $user = call_user_func($hydrators->getHandler($userClass), $data['user'], $hydrators);
             $tag = call_user_func($hydrators->getHandler($tagClass), $data['tag'], $hydrators);
 
             return new FakeArticle($data['id'], $data['title'], $user, $tag);
         });
-        $hydrators->add($userClass, 'user', function(array $data, HydratorContainerInterface $hydrators) use($tagClass) {
+        $hydrators->add($userClass, function(array $data, HydratorContainerInterface $hydrators) use($tagClass) {
             $tag = call_user_func($hydrators->getHandler($tagClass), $data['tag'], $hydrators);
 
             $user = new FakeUser($data['id'], $data['name'], $tag);
@@ -250,12 +260,12 @@ final class SerializardTest extends AbstractTestCase
 
             return $user;
         });
-        $hydrators->add($tagClass, 'tag', function(array $data, HydratorContainerInterface $hydrators) {
+        $hydrators->add($tagClass, function(array $data, HydratorContainerInterface $hydrators) {
             return new FakeTag($data['id'], $data['name']);
         });
 
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($articleClass, 'article', function(FakeArticle $article, NormalizerContextInterface $context) {
+        $normalizers->add($articleClass, function(FakeArticle $article, NormalizerContextInterface $context) {
             return array(
                 'id' => $article->getId(),
                 'title' => $article->getTitle(),
@@ -263,7 +273,7 @@ final class SerializardTest extends AbstractTestCase
                 'tag' => $article->getTag(),
             );
         });
-        $normalizers->add($userClass, 'user', function(FakeUser $user, NormalizerContextInterface $context) {
+        $normalizers->add($userClass, function(FakeUser $user, NormalizerContextInterface $context) {
             return array(
                 'id' => $user->getId(),
                 'name' => $user->getName(),
@@ -271,7 +281,7 @@ final class SerializardTest extends AbstractTestCase
                 'tags' => $user->getTags(),
             );
         });
-        $normalizers->add($tagClass, 'tag', function(FakeTag $tag, NormalizerContextInterface $context) {
+        $normalizers->add($tagClass, function(FakeTag $tag, NormalizerContextInterface $context) {
             return array(
                 'id' => $tag->getId(),
                 'name' => $tag->getName(),
@@ -300,20 +310,20 @@ final class SerializardTest extends AbstractTestCase
         $formats->add('json', new JsonFormat());
 
         $hydrators = new FallbackHydratorContainer();
-        $hydrators->add($articleClass, 'article', new ReflectionHydrator($articleClass, array(
+        $hydrators->add($articleClass, new ReflectionHydrator($articleClass, array(
             'user' => $userClass,
             'tag' => $tagClass,
         )));
-        $hydrators->add($userClass, 'user', new ReflectionHydrator($userClass, array(
+        $hydrators->add($userClass, new ReflectionHydrator($userClass, array(
             'tag' => $tagClass,
             'tags' => $tagClass.'[]',
         )));
-        $hydrators->add($tagClass, 'tag', new ReflectionHydrator($tagClass, array()));
+        $hydrators->add($tagClass, new ReflectionHydrator($tagClass, array()));
 
         $normalizers = new FallbackNormalizerContainer();
-        $normalizers->add($articleClass, 'article', new ReflectionNormalizer());
-        $normalizers->add($userClass, 'user', new ReflectionNormalizer());
-        $normalizers->add($tagClass, 'tag', new ReflectionNormalizer(array('user')));
+        $normalizers->add($articleClass, new ReflectionNormalizer());
+        $normalizers->add($userClass, new ReflectionNormalizer());
+        $normalizers->add($tagClass, new ReflectionNormalizer(array('user')));
 
         $serializard = new Serializard($formats, $normalizers, $hydrators);
 

--- a/tests/SerializardTest.php
+++ b/tests/SerializardTest.php
@@ -23,6 +23,7 @@ use Thunder\Serializard\Tests\Fake\FakeUserParentParent;
 use Thunder\Serializard\Tests\Fake\Interfaces\TypeA;
 use Thunder\Serializard\Tests\Fake\Interfaces\TypeB;
 use Thunder\Serializard\Tests\Fake\Interfaces\TypeInterface;
+use Thunder\Serializard\Utility\RootElementProviderUtility;
 
 /**
  * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
@@ -105,7 +106,10 @@ final class SerializardTest extends AbstractTestCase
         $hydrators = new FallbackHydratorContainer();
 
         $formats = new FormatContainer();
-        $formats->add('xml', new XmlFormat());
+        $formats->add('xml', new XmlFormat(new RootElementProviderUtility([
+            FakeUser::class => 'user',
+            FakeTag::class => 'tag',
+        ])));
         $formats->add('yaml', new YamlFormat());
         $formats->add('json', new JsonFormat());
         $formats->add('array', new ArrayFormat());
@@ -161,18 +165,10 @@ final class SerializardTest extends AbstractTestCase
         });
 
         $formats = new FormatContainer();
-        $formats->add('xml', new XmlFormat(function($class) {
-            static $aliases = [
-                FakeUser::class => 'user',
-                FakeTag::class => 'tag',
-            ];
-
-            if(false === array_key_exists($class, $aliases)) {
-                throw new \RuntimeException(sprintf('No tag name for class %s!', $class));
-            }
-
-            return $aliases[$class];
-        }));
+        $formats->add('xml', new XmlFormat(new RootElementProviderUtility([
+            FakeUser::class => 'user',
+            FakeTag::class => 'tag',
+        ])));
         $formats->add('yaml', new YamlFormat());
         $formats->add('json', new JsonFormat());
         $formats->add('array', new ArrayFormat());

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace Thunder\Serializard\Tests;
+
+use Thunder\Serializard\Utility\RootElementProviderUtility;
+
+/**
+ * @author Tomasz Kowalczyk <tomasz@kowalczyk.cc>
+ */
+final class UtilityTest extends AbstractTestCase
+{
+    public function testInvalidKey()
+    {
+        $this->expectException('InvalidArgumentException');
+        new RootElementProviderUtility([0 => 'Class']);
+    }
+
+    public function testInvalidValue()
+    {
+        $this->expectException('InvalidArgumentException');
+        new RootElementProviderUtility(['Class' => 0]);
+    }
+
+    public function testRootElementAliasNotFound()
+    {
+        $utility = new RootElementProviderUtility([]);
+        $this->expectException('RuntimeException');
+        $utility('invalid');
+    }
+}


### PR DESCRIPTION
- [x] normalizers container and hydrators container no longer require root element key,
- [x] root element alias handling was moved to `XmlFormat` as it is the only one that required it,
- [x] introduced `RootElementProviderUtility` to ease creation of these aliases,
- [x] formally increased minimum PHP version to 5.5 in `composer.json`,
- [x] updated README.